### PR TITLE
Extract ThreadContext from Context and add UntypedContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # Propagation.io
-Prototype of a split io.grpc.Context
+A standalone context propagation library for Java
+that is focused on improving interoperability
+across existing context propagation APIs like gRPC Context and Reactor.
+
+# Design questions
+
+### Should the context have a thread-based "current" concept?
+
+Having a thread-based "current" context makes sense in some environments,
+but doesn't make sense in others.
+
+Reflecting that, some existing libraries like gRPC Context have this concept,
+while some existing libraries like Reactor do not.
+
+So, in order to improve interoperability across existing context propagation APIs,
+the current proposal provides both options on top of the same immutable data structure
+in order to make transitioning between them efficient
+(see `Context` and `ThreadContext`).
+
+### Should the context have typed keys?
+
+Having typed keys seems to be generally preferable
+(we are interested to learn more about use cases where they are not!).
+
+However, some existing libraries like gRPC Context use typed keys,
+and some existing libraries like Reactor do not.
+
+So, in order to improve interoperability across existing context propagation APIs,
+the current proposal provides both options on top of the same immutable data structure
+in order to make transitioning between them efficient
+(see `Context` and `UntypedContext`).
+
+\[Note: there's no `UntypedThreadContext` yet, we need to investigate more libraries
+and hear from more folks to know if this is needed.]
+
+### Should this project support Java 7?
+
+Supporting Java 7 limits some design choices,
+but is a requirement for both gRPC and OpenTelemetry.
+
+### Should context be an interface or an abstract class?
+
+Since we are limited to Java 7, `Context`, `ThreadContext`, and `UntypedContext`
+have been implemented as abstract classes instead of interfaces
+so that their related static methods can be collocated in the same place,
+making the API surface feel smaller and improving discoverability.
+
+Alternatively, we could make them interfaces and move the static methods to
+corresponding util classes (e.g. `Contexts`, `ThreadContexts`,
+and `UntypedContexts`), which would give implementations more flexibility.

--- a/context/src/main/java/io/propagation/Context.java
+++ b/context/src/main/java/io/propagation/Context.java
@@ -81,6 +81,8 @@ public abstract class Context {
   public abstract <V1, V2, V3, V4> Context withValues(
       Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3, Key<V4> k4, V4 v4);
 
+  public abstract UntypedContext toUntyped();
+
   protected abstract <T> T get(Key<T> key);
 
   /** Key for indexing values stored in a context. */

--- a/context/src/main/java/io/propagation/Context.java
+++ b/context/src/main/java/io/propagation/Context.java
@@ -16,107 +16,7 @@
 
 package io.propagation;
 
-import io.propagation.PersistentHashArrayMappedTrie.Node;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nullable;
-
-/**
- * A context propagation mechanism which can carry scoped-values across API boundaries and between
- * threads. Examples of state propagated via context include:
- *
- * <ul>
- *   <li>Security principals and credentials.
- *   <li>Local and distributed tracing information.
- * </ul>
- *
- * <p>A Context object can be {@link #attach attached} to the {@link Storage}, which effectively
- * forms a <b>scope</b> for the context. The scope is bound to the current thread. Within a scope,
- * its Context is accessible even across API boundaries, through {@link #current}. The scope is
- * later exited by {@link #detach detaching} the Context.
- *
- * <p>Context objects are immutable and inherit state from their parent. To add or overwrite the
- * current state a new context object must be created and then attached, replacing the previously
- * bound context. For example:
- *
- * <pre>
- *   Context withCredential = Context.current().withValue(CRED_KEY, cred);
- *   withCredential.run(new Runnable() {
- *     public void run() {
- *        readUserRecords(userId, CRED_KEY.get());
- *     }
- *   });
- * </pre>
- *
- * <p>Notes and cautions on use:
- *
- * <ul>
- *   <li>Every {@code attach()} should have a {@code detach()} in the same method. Breaking this
- *       rules may lead to memory leaks.
- *   <li>While Context objects are immutable they do not place such a restriction on the state they
- *       store.
- *   <li>Context is not intended for passing optional parameters to an API and developers should
- *       take care to avoid excessive dependence on context when designing an API.
- *   <li>Do not mock this class. Use {@link #ROOT} for a non-null instance.
- * </ul>
- */
-/* @DoNotMock("Use ROOT for a non-null Context") // commented out to avoid dependencies  */
-public class Context {
-  private static final Logger log = Logger.getLogger(Context.class.getName());
-
-  // Long chains of contexts are suspicious and usually indicate a misuse of Context.
-  // The threshold is arbitrarily chosen.
-  // VisibleForTesting
-  static final int CONTEXT_DEPTH_WARN_THRESH = 1000;
-
-  /**
-   * The logical root context which is the ultimate ancestor of all contexts.
-   *
-   * <p>Never assume this is the default context for new threads, because {@link Storage} may define
-   * a default context that is different from ROOT.
-   */
-  public static final Context ROOT = new Context();
-
-  // VisibleForTesting
-  static Storage storage() {
-    return LazyStorage.storage;
-  }
-
-  // Lazy-loaded storage. Delaying storage initialization until after class initialization makes it
-  // much easier to avoid circular loading since there can still be references to Context as long as
-  // they don't depend on storage, like key() and currentContextExecutor(). It also makes it easier
-  // to handle exceptions.
-  private static final class LazyStorage {
-    static final Storage storage;
-
-    static {
-      AtomicReference<Throwable> deferredStorageFailure = new AtomicReference<>();
-      storage = createStorage(deferredStorageFailure);
-      Throwable failure = deferredStorageFailure.get();
-      // Logging must happen after storage has been set, as loggers may use Context.
-      if (failure != null) {
-        log.log(Level.FINE, "Storage override doesn't exist. Using default", failure);
-      }
-    }
-
-    private static Storage createStorage(
-        AtomicReference<? super ClassNotFoundException> deferredStorageFailure) {
-      try {
-        Class<?> clazz = Class.forName("io.propagation.override.ContextStorageOverride");
-        // The override's constructor is prohibited from triggering any code that can loop back to
-        // Context
-        return clazz.asSubclass(Storage.class).getConstructor().newInstance();
-      } catch (ClassNotFoundException e) {
-        deferredStorageFailure.set(e);
-        return new ThreadLocalContextStorage();
-      } catch (Exception e) {
-        throw new RuntimeException("Storage override failed to initialize", e);
-      }
-    }
-  }
+public abstract class Context {
 
   /**
    * Create a {@link Key} with the given debug name. Multiple different keys may have the same name;
@@ -134,43 +34,12 @@ public class Context {
     return new Key<>(name, defaultValue);
   }
 
-  /** Return the context associated with the current scope, will never return {@code null}. */
-  public static Context current() {
-    Context current = storage().current();
-    if (current == null) {
-      return ROOT;
-    }
-    return current;
-  }
-
-  @Nullable final Node<Key<?>, Object> keyValueEntries;
-  // The number parents between this context and the root context.
-  final int generation;
-
-  private Context(Context parent, Node<Key<?>, Object> keyValueEntries) {
-    this.keyValueEntries = keyValueEntries;
-    this.generation = parent.generation + 1;
-    validateGeneration(generation);
-  }
-
-  /** Construct for {@link #ROOT}. */
-  private Context() {
-    this.keyValueEntries = null;
-    this.generation = 0;
-    validateGeneration(generation);
+  public static Context empty() {
+    return PersistentHashArrayMappedTrie.EmptyNode.INSTANCE;
   }
 
   /**
    * Create a new context with the given key value set.
-   *
-   * <pre>
-   *   Context withCredential = Context.current().withValue(CRED_KEY, cred);
-   *   withCredential.run(new Runnable() {
-   *     public void run() {
-   *        readUserRecords(userId, CRED_KEY.get());
-   *     }
-   *   });
-   * </pre>
    *
    * <p>Note that multiple calls to {@code #withValue} can be chained together. That is,
    *
@@ -184,28 +53,14 @@ public class Context {
    * number of keys and values — combine multiple related items together into a single key instead
    * of separating them. But if the items are unrelated, have separate keys for them.
    */
-  public <V> Context withValue(Key<V> k1, V v1) {
-    Node<Key<?>, Object> newKeyValueEntries =
-        PersistentHashArrayMappedTrie.put(keyValueEntries, k1, v1);
-    return new Context(this, newKeyValueEntries);
-  }
+  public abstract <V1> Context withValue(Key<V1> k1, V1 v1);
 
   /** Create a new context with the given key value set. */
-  public <V1, V2> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2) {
-    Node<Key<?>, Object> newKeyValueEntries =
-        PersistentHashArrayMappedTrie.put(keyValueEntries, k1, v1);
-    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
-    return new Context(this, newKeyValueEntries);
-  }
+  public abstract <V1, V2> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2);
 
   /** Create a new context with the given key value set. */
-  public <V1, V2, V3> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3) {
-    Node<Key<?>, Object> newKeyValueEntries =
-        PersistentHashArrayMappedTrie.put(keyValueEntries, k1, v1);
-    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
-    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k3, v3);
-    return new Context(this, newKeyValueEntries);
-  }
+  public abstract <V1, V2, V3> Context withValues(
+      Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3);
 
   /**
    * Create a new context with the given key value set.
@@ -223,187 +78,28 @@ public class Context {
    * number of keys and values — combine multiple related items together into a single key instead
    * of separating them. But if the items are unrelated, have separate keys for them.
    */
-  public <V1, V2, V3, V4> Context withValues(
-      Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3, Key<V4> k4, V4 v4) {
-    Node<Key<?>, Object> newKeyValueEntries =
-        PersistentHashArrayMappedTrie.put(keyValueEntries, k1, v1);
-    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
-    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k3, v3);
-    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k4, v4);
-    return new Context(this, newKeyValueEntries);
-  }
+  public abstract <V1, V2, V3, V4> Context withValues(
+      Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3, Key<V4> k4, V4 v4);
 
-  /**
-   * Attach this context, thus enter a new scope within which this context is {@link #current}. The
-   * previously current context is returned.
-   *
-   * <p>Instead of using {@code attach()} and {@link #detach(Context)} most use-cases are better
-   * served by using the {@link #run(Runnable)} or {@link #call(java.util.concurrent.Callable)} to
-   * execute work immediately within a context's scope. If work needs to be done in other threads it
-   * is recommended to use the 'wrap' methods or to use a propagating executor.
-   *
-   * <p>All calls to {@code attach()} should have a corresponding {@link #detach(Context)} within
-   * the same method:
-   *
-   * <pre>{@code Context previous = someContext.attach();
-   * try {
-   *   // Do work
-   * } finally {
-   *   someContext.detach(previous);
-   * }}</pre>
-   */
-  public Context attach() {
-    Context prev = storage().doAttach(this);
-    if (prev == null) {
-      return ROOT;
-    }
-    return prev;
-  }
-
-  /**
-   * Reverse an {@code attach()}, restoring the previous context and exiting the current scope.
-   *
-   * <p>This context should be the same context that was previously {@link #attach attached}. The
-   * provided replacement should be what was returned by the same {@link #attach attach()} call. If
-   * an {@code attach()} and a {@code detach()} meet above requirements, they match.
-   *
-   * <p>It is expected that between any pair of matching {@code attach()} and {@code detach()}, all
-   * {@code attach()}es and {@code detach()}es are called in matching pairs. If this method finds
-   * that this context is not {@link #current current}, either you or some code in-between are not
-   * detaching correctly, and a SEVERE message will be logged but the context to attach will still
-   * be bound. <strong>Never</strong> use {@code Context.current().detach()}, as this will
-   * compromise this error-detecting mechanism.
-   */
-  public void detach(Context toAttach) {
-    checkNotNull(toAttach, "toAttach");
-    storage().detach(this, toAttach);
-  }
-
-  /**
-   * Immediately run a {@link Runnable} with this context as the {@link #current} context.
-   *
-   * @param r {@link Runnable} to run.
-   */
-  public void run(Runnable r) {
-    Context previous = attach();
-    try {
-      r.run();
-    } finally {
-      detach(previous);
-    }
-  }
-
-  /**
-   * Immediately call a {@link Callable} with this context as the {@link #current} context.
-   *
-   * @param c {@link Callable} to call.
-   * @return result of call.
-   */
-  public <V> V call(Callable<V> c) throws Exception {
-    Context previous = attach();
-    try {
-      return c.call();
-    } finally {
-      detach(previous);
-    }
-  }
-
-  /**
-   * Wrap a {@link Runnable} so that it executes with this context as the {@link #current} context.
-   */
-  public Runnable wrap(final Runnable r) {
-    return new Runnable() {
-      @Override
-      public void run() {
-        Context previous = attach();
-        try {
-          r.run();
-        } finally {
-          detach(previous);
-        }
-      }
-    };
-  }
-
-  /**
-   * Wrap a {@link Callable} so that it executes with this context as the {@link #current} context.
-   */
-  public <C> Callable<C> wrap(final Callable<C> c) {
-    return new Callable<C>() {
-      @Override
-      public C call() throws Exception {
-        Context previous = attach();
-        try {
-          return c.call();
-        } finally {
-          detach(previous);
-        }
-      }
-    };
-  }
-
-  /**
-   * Wrap an {@link Executor} so that it always executes with this context as the {@link #current}
-   * context. It is generally expected that {@link #currentContextExecutor(Executor)} would be used
-   * more commonly than this method.
-   *
-   * <p>One scenario in which this executor may be useful is when a single thread is sharding work
-   * to multiple threads.
-   *
-   * @see #currentContextExecutor(Executor)
-   */
-  public Executor fixedContextExecutor(final Executor e) {
-    final class FixedContextExecutor implements Executor {
-      @Override
-      public void execute(Runnable r) {
-        e.execute(wrap(r));
-      }
-    }
-
-    return new FixedContextExecutor();
-  }
-
-  /**
-   * Create an executor that propagates the {@link #current} context when {@link Executor#execute}
-   * is called as the {@link #current} context of the {@code Runnable} scheduled. <em>Note that this
-   * is a static method.</em>
-   *
-   * @see #fixedContextExecutor(Executor)
-   */
-  public static Executor currentContextExecutor(final Executor e) {
-    final class CurrentContextExecutor implements Executor {
-      @Override
-      public void execute(Runnable r) {
-        e.execute(Context.current().wrap(r));
-      }
-    }
-
-    return new CurrentContextExecutor();
-  }
+  protected abstract <T> T get(Key<T> key);
 
   /** Key for indexing values stored in a context. */
-  public static final class Key<T> {
+  public static class Key<T> {
     private final String name;
     private final T defaultValue;
 
-    Key(String name) {
+    protected Key(String name) {
       this(name, null);
     }
 
-    Key(String name, T defaultValue) {
+    protected Key(String name, T defaultValue) {
       this.name = checkNotNull(name, "name");
       this.defaultValue = defaultValue;
     }
 
-    /** Get the value from the {@link #current()} context for this key. */
-    public T get() {
-      return get(Context.current());
-    }
-
     /** Get the value from the specified context for this key. */
-    @SuppressWarnings("unchecked")
     public T get(Context context) {
-      T value = (T) PersistentHashArrayMappedTrie.get(context.keyValueEntries, this);
+      T value = context.get(this);
       return value == null ? defaultValue : value;
     }
 
@@ -411,82 +107,12 @@ public class Context {
     public String toString() {
       return name;
     }
-  }
 
-  private static <T> T checkNotNull(T reference, Object errorMessage) {
-    if (reference == null) {
-      throw new NullPointerException(String.valueOf(errorMessage));
+    private static <T> T checkNotNull(T reference, String errorMessage) {
+      if (reference == null) {
+        throw new NullPointerException(errorMessage);
+      }
+      return reference;
     }
-    return reference;
-  }
-
-  /**
-   * If the ancestry chain length is unreasonably long, then print an error to the log and record
-   * the stack trace.
-   */
-  private static void validateGeneration(int generation) {
-    if (generation == CONTEXT_DEPTH_WARN_THRESH) {
-      log.log(
-          Level.SEVERE,
-          "Context ancestry chain length is abnormally long. "
-              + "This suggests an error in application code. "
-              + "Length exceeded: "
-              + CONTEXT_DEPTH_WARN_THRESH,
-          new Exception());
-    }
-  }
-
-  /**
-   * Defines the mechanisms for attaching and detaching the "current" context. The constructor for
-   * extending classes <em>must not</em> trigger any activity that can use Context, which includes
-   * logging, otherwise it can trigger an infinite initialization loop. Extending classes must not
-   * assume that only one instance will be created; Context guarantees it will only use one
-   * instance, but it may create multiple and then throw away all but one.
-   *
-   * <p>The default implementation will put the current context in a {@link ThreadLocal}. If an
-   * alternative implementation named {@code io.propagation.override.ContextStorageOverride} exists
-   * in the classpath, it will be used instead of the default implementation.
-   *
-   * <p>This API is <a href="https://github.com/grpc/grpc-java/issues/2462">experimental</a> and
-   * subject to change.
-   */
-  public abstract static class Storage {
-    /**
-     * Implements {@link Context#attach}.
-     *
-     * <p>Caution: {@link Context#attach()} interprets a return value of {@code null} to mean the
-     * same thing as {@link Context#ROOT}.
-     *
-     * <p>See also: {@link #current()}.
-     *
-     * @param toAttach the context to be attached
-     * @return A {@link Context} that should be passed back into {@link #detach(Context, Context)}
-     *     as the {@code toRestore} parameter. {@code null} is a valid return value, but see caution
-     *     note.
-     */
-    public abstract Context doAttach(Context toAttach);
-
-    /**
-     * Implements {@link Context#detach}.
-     *
-     * @param toDetach the context to be detached. Should be, or be equivalent to, the current
-     *     context of the current scope
-     * @param toRestore the context to be the current. Should be, or be equivalent to, the context
-     *     of the outer scope
-     */
-    public abstract void detach(Context toDetach, Context toRestore);
-
-    /**
-     * Implements {@link Context#current}.
-     *
-     * <p>Caution: {@link Context} interprets a return value of {@code null} to mean the same thing
-     * as {@code Context{@link Context#ROOT}}.
-     *
-     * <p>See also {@link #doAttach(Context)}.
-     *
-     * @return The context of the current scope. {@code null} is a valid return value, but see
-     *     caution note.
-     */
-    public abstract Context current();
   }
 }

--- a/context/src/main/java/io/propagation/DefaultUntypedContext.java
+++ b/context/src/main/java/io/propagation/DefaultUntypedContext.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Propagation.io Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.propagation;
+
+import javax.annotation.Nullable;
+
+public class DefaultUntypedContext extends UntypedContext {
+
+  static final UntypedContext EMPTY = new DefaultUntypedContext();
+
+  @Nullable private final PersistentHashArrayMappedTrie.Node keyValueEntries;
+
+  // this is used by UntypedContext.wrap(Context)
+  DefaultUntypedContext(Context context) {
+    this.keyValueEntries = null;
+  }
+
+  /** Construct for {@link #EMPTY}. */
+  private DefaultUntypedContext() {
+    this.keyValueEntries = null;
+  }
+
+  @Override
+  @Nullable
+  public Object get(Object key) {
+    return PersistentHashArrayMappedTrie.get(keyValueEntries, key);
+  }
+
+  @Override
+  public UntypedContext withValue(Object k1, Object v1) {
+    return new DefaultUntypedContext(PersistentHashArrayMappedTrie.put(keyValueEntries, k1, v1));
+  }
+
+  @Override
+  public UntypedContext withValues(Object k1, Object v1, Object k2, Object v2) {
+    return new DefaultUntypedContext(
+        PersistentHashArrayMappedTrie.withValues(keyValueEntries, k1, v1, k2, v2));
+  }
+
+  @Override
+  public UntypedContext withValues(
+      Object k1, Object v1, Object k2, Object v2, Object k3, Object v3) {
+    return new DefaultUntypedContext(
+        PersistentHashArrayMappedTrie.withValues(keyValueEntries, k1, v1, k2, v2, k3, v3));
+  }
+
+  @Override
+  public UntypedContext withValues(
+      Object k1, Object v1, Object k2, Object v2, Object k3, Object v3, Object k4, Object v4) {
+    return new DefaultUntypedContext(
+        PersistentHashArrayMappedTrie.withValues(keyValueEntries, k1, v1, k2, v2, k3, v3, k4, v4));
+  }
+
+  @Override
+  public Context toTyped() {
+    return keyValueEntries == null ? Context.empty() : keyValueEntries;
+  }
+}

--- a/context/src/main/java/io/propagation/PersistentHashArrayMappedTrie.java
+++ b/context/src/main/java/io/propagation/PersistentHashArrayMappedTrie.java
@@ -314,6 +314,11 @@ final class PersistentHashArrayMappedTrie {
     }
 
     @Override
+    public UntypedContext toUntyped() {
+      return UntypedContext.empty();
+    }
+
+    @Override
     @Nullable
     protected <T> T get(Key<T> key) {
       return null;
@@ -344,6 +349,11 @@ final class PersistentHashArrayMappedTrie {
     }
 
     @Override
+    public UntypedContext toUntyped() {
+      return new DefaultUntypedContext(this);
+    }
+
+    @Override
     @Nullable
     @SuppressWarnings("unchecked")
     protected <T> T get(Key<T> key) {
@@ -357,19 +367,19 @@ final class PersistentHashArrayMappedTrie {
     abstract int size();
   }
 
-  private static Context withValues(Node root, Object k1, Object v1, Object k2, Object v2) {
+  static Node withValues(Node root, Object k1, Object v1, Object k2, Object v2) {
     Node newKeyValueEntries = PersistentHashArrayMappedTrie.put(root, k1, v1);
     return PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
   }
 
-  private static Context withValues(
+  static Node withValues(
       Node root, Object k1, Object v1, Object k2, Object v2, Object k3, Object v3) {
     Node newKeyValueEntries = PersistentHashArrayMappedTrie.put(root, k1, v1);
     newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
     return PersistentHashArrayMappedTrie.put(newKeyValueEntries, k3, v3);
   }
 
-  private static Context withValues(
+  static Node withValues(
       Node root,
       Object k1,
       Object v1,

--- a/context/src/main/java/io/propagation/PersistentHashArrayMappedTrie.java
+++ b/context/src/main/java/io/propagation/PersistentHashArrayMappedTrie.java
@@ -34,7 +34,7 @@ final class PersistentHashArrayMappedTrie {
 
   /** Returns the value with the specified key, or {@code null} if it does not exist. */
   @Nullable
-  static <K, V> V get(Node<K, V> root, K key) {
+  static Object get(Node root, Object key) {
     if (root == null) {
       return null;
     }
@@ -42,9 +42,9 @@ final class PersistentHashArrayMappedTrie {
   }
 
   /** Returns a new root {@code Node} where the key is set to the specified value. */
-  static <K, V> Node<K, V> put(Node<K, V> root, K key, V value) {
+  static <K, V> Node put(Node root, K key, V value) {
     if (root == null) {
-      return new Leaf<>(key, value);
+      return new Leaf(key, value);
     } else {
       return root.put(key, value, key.hashCode(), 0);
     }
@@ -52,11 +52,11 @@ final class PersistentHashArrayMappedTrie {
 
   // Not actually annotated to avoid depending on guava
   // @VisibleForTesting
-  static final class Leaf<K, V> extends Node<K, V> {
-    private final K key;
-    private final V value;
+  static final class Leaf extends Node {
+    private final Object key;
+    private final Object value;
 
-    Leaf(K key, V value) {
+    Leaf(Object key, Object value) {
       this.key = key;
       this.value = value;
     }
@@ -68,7 +68,7 @@ final class PersistentHashArrayMappedTrie {
 
     @Override
     @Nullable
-    V get(K key, int hash, int bitsConsumed) {
+    Object get(Object key, int hash, int bitsConsumed) {
       if (this.key == key) {
         return value;
       } else {
@@ -77,17 +77,17 @@ final class PersistentHashArrayMappedTrie {
     }
 
     @Override
-    Node<K, V> put(K key, V value, int hash, int bitsConsumed) {
+    Node put(Object key, Object value, int hash, int bitsConsumed) {
       int thisHash = this.key.hashCode();
       if (thisHash != hash) {
         // Insert
-        return CompressedIndex.combine(new Leaf<>(key, value), hash, this, thisHash, bitsConsumed);
+        return CompressedIndex.combine(new Leaf(key, value), hash, this, thisHash, bitsConsumed);
       } else if (this.key == key) {
         // Replace
-        return new Leaf<>(key, value);
+        return new Leaf(key, value);
       } else {
         // Hash collision
-        return new CollisionLeaf<>(this.key, this.value, key, value);
+        return new CollisionLeaf(this.key, this.value, key, value);
       }
     }
 
@@ -99,21 +99,20 @@ final class PersistentHashArrayMappedTrie {
 
   // Not actually annotated to avoid depending on guava
   // @VisibleForTesting
-  static final class CollisionLeaf<K, V> extends Node<K, V> {
+  static final class CollisionLeaf extends Node {
     // All keys must have same hash, but not have the same reference
-    private final K[] keys;
-    private final V[] values;
+    private final Object[] keys;
+    private final Object[] values;
 
     // Not actually annotated to avoid depending on guava
     // @VisibleForTesting
-    @SuppressWarnings("unchecked")
-    CollisionLeaf(K key1, V value1, K key2, V value2) {
-      this((K[]) new Object[] {key1, key2}, (V[]) new Object[] {value1, value2});
+    CollisionLeaf(Object key1, Object value1, Object key2, Object value2) {
+      this(new Object[] {key1, key2}, new Object[] {value1, value2});
       assert key1 != key2;
       assert key1.hashCode() == key2.hashCode();
     }
 
-    private CollisionLeaf(K[] keys, V[] values) {
+    private CollisionLeaf(Object[] keys, Object[] values) {
       this.keys = keys;
       this.values = values;
     }
@@ -125,7 +124,7 @@ final class PersistentHashArrayMappedTrie {
 
     @Override
     @Nullable
-    V get(K key, int hash, int bitsConsumed) {
+    Object get(Object key, int hash, int bitsConsumed) {
       for (int i = 0; i < keys.length; i++) {
         if (keys[i] == key) {
           return values[i];
@@ -135,31 +134,31 @@ final class PersistentHashArrayMappedTrie {
     }
 
     @Override
-    Node<K, V> put(K key, V value, int hash, int bitsConsumed) {
+    Node put(Object key, Object value, int hash, int bitsConsumed) {
       int thisHash = keys[0].hashCode();
       int keyIndex;
       if (thisHash != hash) {
         // Insert
-        return CompressedIndex.combine(new Leaf<>(key, value), hash, this, thisHash, bitsConsumed);
+        return CompressedIndex.combine(new Leaf(key, value), hash, this, thisHash, bitsConsumed);
       } else if ((keyIndex = indexOfKey(key)) != -1) {
         // Replace
-        K[] newKeys = Arrays.copyOf(keys, keys.length);
-        V[] newValues = Arrays.copyOf(values, keys.length);
+        Object[] newKeys = Arrays.copyOf(keys, keys.length);
+        Object[] newValues = Arrays.copyOf(values, keys.length);
         newKeys[keyIndex] = key;
         newValues[keyIndex] = value;
-        return new CollisionLeaf<>(newKeys, newValues);
+        return new CollisionLeaf(newKeys, newValues);
       } else {
         // Yet another hash collision
-        K[] newKeys = Arrays.copyOf(keys, keys.length + 1);
-        V[] newValues = Arrays.copyOf(values, keys.length + 1);
+        Object[] newKeys = Arrays.copyOf(keys, keys.length + 1);
+        Object[] newValues = Arrays.copyOf(values, keys.length + 1);
         newKeys[keys.length] = key;
         newValues[keys.length] = value;
-        return new CollisionLeaf<>(newKeys, newValues);
+        return new CollisionLeaf(newKeys, newValues);
       }
     }
 
     // -1 if not found
-    private int indexOfKey(K key) {
+    private int indexOfKey(Object key) {
       for (int i = 0; i < keys.length; i++) {
         if (keys[i] == key) {
           return i;
@@ -181,15 +180,15 @@ final class PersistentHashArrayMappedTrie {
 
   // Not actually annotated to avoid depending on guava
   // @VisibleForTesting
-  static final class CompressedIndex<K, V> extends Node<K, V> {
+  static final class CompressedIndex extends Node {
     private static final int BITS = 5;
     private static final int BITS_MASK = 0x1F;
 
-    final Node<K, V>[] values;
+    final Node[] values;
     private final int size;
     final int bitmap;
 
-    private CompressedIndex(int bitmap, Node<K, V>[] values, int size) {
+    private CompressedIndex(int bitmap, Node[] values, int size) {
       this.bitmap = bitmap;
       this.values = values;
       this.size = size;
@@ -202,7 +201,7 @@ final class PersistentHashArrayMappedTrie {
 
     @Override
     @Nullable
-    V get(K key, int hash, int bitsConsumed) {
+    Object get(Object key, int hash, int bitsConsumed) {
       int indexBit = indexBit(hash, bitsConsumed);
       if ((bitmap & indexBit) == 0) {
         return null;
@@ -212,55 +211,51 @@ final class PersistentHashArrayMappedTrie {
     }
 
     @Override
-    Node<K, V> put(K key, V value, int hash, int bitsConsumed) {
+    Node put(Object key, Object value, int hash, int bitsConsumed) {
       int indexBit = indexBit(hash, bitsConsumed);
       int compressedIndex = compressedIndex(indexBit);
       if ((bitmap & indexBit) == 0) {
         // Insert
         int newBitmap = bitmap | indexBit;
-        @SuppressWarnings("unchecked")
-        Node<K, V>[] newValues = (Node<K, V>[]) new Node<?, ?>[values.length + 1];
+        Node[] newValues = new Node[values.length + 1];
         System.arraycopy(values, 0, newValues, 0, compressedIndex);
-        newValues[compressedIndex] = new Leaf<>(key, value);
+        newValues[compressedIndex] = new Leaf(key, value);
         System.arraycopy(
             values,
             compressedIndex,
             newValues,
             compressedIndex + 1,
             values.length - compressedIndex);
-        return new CompressedIndex<>(newBitmap, newValues, size() + 1);
+        return new CompressedIndex(newBitmap, newValues, size() + 1);
       } else {
         // Replace
-        Node<K, V>[] newValues = Arrays.copyOf(values, values.length);
+        Node[] newValues = Arrays.copyOf(values, values.length);
         newValues[compressedIndex] =
             values[compressedIndex].put(key, value, hash, bitsConsumed + BITS);
         int newSize = size();
         newSize += newValues[compressedIndex].size();
         newSize -= values[compressedIndex].size();
-        return new CompressedIndex<>(bitmap, newValues, newSize);
+        return new CompressedIndex(bitmap, newValues, newSize);
       }
     }
 
-    static <K, V> Node<K, V> combine(
-        Node<K, V> node1, int hash1, Node<K, V> node2, int hash2, int bitsConsumed) {
+    static <K, V> Node combine(Node node1, int hash1, Node node2, int hash2, int bitsConsumed) {
       assert hash1 != hash2;
       int indexBit1 = indexBit(hash1, bitsConsumed);
       int indexBit2 = indexBit(hash2, bitsConsumed);
       if (indexBit1 == indexBit2) {
-        Node<K, V> node = combine(node1, hash1, node2, hash2, bitsConsumed + BITS);
-        @SuppressWarnings("unchecked")
-        Node<K, V>[] values = (Node<K, V>[]) new Node<?, ?>[] {node};
-        return new CompressedIndex<>(indexBit1, values, node.size());
+        Node node = combine(node1, hash1, node2, hash2, bitsConsumed + BITS);
+        Node[] values = new Node[] {node};
+        return new CompressedIndex(indexBit1, values, node.size());
       } else {
         // Make node1 the smallest
         if (uncompressedIndex(hash1, bitsConsumed) > uncompressedIndex(hash2, bitsConsumed)) {
-          Node<K, V> nodeCopy = node1;
+          Node nodeCopy = node1;
           node1 = node2;
           node2 = nodeCopy;
         }
-        @SuppressWarnings("unchecked")
-        Node<K, V>[] values = (Node<K, V>[]) new Node<?, ?>[] {node1, node2};
-        return new CompressedIndex<>(indexBit1 | indexBit2, values, node1.size() + node2.size());
+        Node[] values = new Node[] {node1, node2};
+        return new CompressedIndex(indexBit1 | indexBit2, values, node1.size() + node2.size());
       }
     }
 
@@ -270,7 +265,7 @@ final class PersistentHashArrayMappedTrie {
       valuesSb
           .append("CompressedIndex(")
           .append(String.format("bitmap=%s ", Integer.toBinaryString(bitmap)));
-      for (Node<K, V> value : values) {
+      for (Node value : values) {
         valuesSb.append(value).append(" ");
       }
       return valuesSb.append(")").toString();
@@ -290,11 +285,103 @@ final class PersistentHashArrayMappedTrie {
     }
   }
 
-  abstract static class Node<K, V> {
-    abstract V get(K key, int hash, int bitsConsumed);
+  static final class EmptyNode extends Context {
 
-    abstract Node<K, V> put(K key, V value, int hash, int bitsConsumed);
+    static final Context INSTANCE = new EmptyNode();
+
+    private EmptyNode() {}
+
+    @Override
+    public <V1> Context withValue(Key<V1> k1, V1 v1) {
+      return PersistentHashArrayMappedTrie.put(null, k1, v1);
+    }
+
+    @Override
+    public <V1, V2> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2) {
+      return PersistentHashArrayMappedTrie.withValues(null, k1, v1, k2, v2);
+    }
+
+    @Override
+    public <V1, V2, V3> Context withValues(
+        Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3) {
+      return PersistentHashArrayMappedTrie.withValues(null, k1, v1, k2, v2, k3, v3);
+    }
+
+    @Override
+    public <V1, V2, V3, V4> Context withValues(
+        Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3, Key<V4> k4, V4 v4) {
+      return PersistentHashArrayMappedTrie.withValues(null, k1, v1, k2, v2, k3, v3, k4, v4);
+    }
+
+    @Override
+    @Nullable
+    protected <T> T get(Key<T> key) {
+      return null;
+    }
+  }
+
+  abstract static class Node extends Context {
+    @Override
+    public <V1> Context withValue(Key<V1> k1, V1 v1) {
+      return PersistentHashArrayMappedTrie.put(this, k1, v1);
+    }
+
+    @Override
+    public <V1, V2> Context withValues(Key<V1> k1, V1 v1, Key<V2> k2, V2 v2) {
+      return PersistentHashArrayMappedTrie.withValues(this, k1, v1, k2, v2);
+    }
+
+    @Override
+    public <V1, V2, V3> Context withValues(
+        Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3) {
+      return PersistentHashArrayMappedTrie.withValues(this, k1, v1, k2, v2, k3, v3);
+    }
+
+    @Override
+    public <V1, V2, V3, V4> Context withValues(
+        Key<V1> k1, V1 v1, Key<V2> k2, V2 v2, Key<V3> k3, V3 v3, Key<V4> k4, V4 v4) {
+      return PersistentHashArrayMappedTrie.withValues(this, k1, v1, k2, v2, k3, v3, k4, v4);
+    }
+
+    @Override
+    @Nullable
+    @SuppressWarnings("unchecked")
+    protected <T> T get(Key<T> key) {
+      return (T) PersistentHashArrayMappedTrie.get(this, key);
+    }
+
+    abstract Object get(Object key, int hash, int bitsConsumed);
+
+    abstract Node put(Object key, Object value, int hash, int bitsConsumed);
 
     abstract int size();
+  }
+
+  private static Context withValues(Node root, Object k1, Object v1, Object k2, Object v2) {
+    Node newKeyValueEntries = PersistentHashArrayMappedTrie.put(root, k1, v1);
+    return PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
+  }
+
+  private static Context withValues(
+      Node root, Object k1, Object v1, Object k2, Object v2, Object k3, Object v3) {
+    Node newKeyValueEntries = PersistentHashArrayMappedTrie.put(root, k1, v1);
+    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
+    return PersistentHashArrayMappedTrie.put(newKeyValueEntries, k3, v3);
+  }
+
+  private static Context withValues(
+      Node root,
+      Object k1,
+      Object v1,
+      Object k2,
+      Object v2,
+      Object k3,
+      Object v3,
+      Object k4,
+      Object v4) {
+    Node newKeyValueEntries = PersistentHashArrayMappedTrie.put(root, k1, v1);
+    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k2, v2);
+    newKeyValueEntries = PersistentHashArrayMappedTrie.put(newKeyValueEntries, k3, v3);
+    return PersistentHashArrayMappedTrie.put(newKeyValueEntries, k4, v4);
   }
 }

--- a/context/src/main/java/io/propagation/UntypedContext.java
+++ b/context/src/main/java/io/propagation/UntypedContext.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Propagation.io Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.propagation;
+
+public abstract class UntypedContext {
+
+  public static UntypedContext empty() {
+    return DefaultUntypedContext.EMPTY;
+  }
+
+  public abstract Object get(Object key);
+
+  /**
+   * Create a new context with the given key value set.
+   *
+   * <p>Note that multiple calls to {@code #withValue} can be chained together. That is,
+   *
+   * <pre>
+   * context.withValues(k1, v1, k2, v2);
+   * // is the same as
+   * context.withValue(k1, v1).withValue(k2, v2);
+   * </pre>
+   *
+   * <p>Nonetheless, {@link UntypedContext} should not be treated like a general purpose map with a
+   * large number of keys and values — combine multiple related items together into a single key
+   * instead of separating them. But if the items are unrelated, have separate keys for them.
+   */
+  public abstract UntypedContext withValue(Object k1, Object v1);
+
+  /** Create a new context with the given key value set. */
+  public abstract UntypedContext withValues(Object k1, Object v1, Object k2, Object v2);
+
+  /** Create a new context with the given key value set. */
+  public abstract UntypedContext withValues(
+      Object k1, Object v1, Object k2, Object v2, Object k3, Object v3);
+
+  /**
+   * Create a new context with the given key value set.
+   *
+   * <p>For more than 4 key-value pairs, note that multiple calls to {@link #withValue} can be
+   * chained together. That is,
+   *
+   * <pre>
+   * context.withValues(k1, v1, k2, v2);
+   * // is the same as
+   * context.withValue(k1, v1).withValue(k2, v2);
+   * </pre>
+   *
+   * <p>Nonetheless, {@link UntypedContext} should not be treated like a general purpose map with a
+   * large number of keys and values — combine multiple related items together into a single key
+   * instead of separating them. But if the items are unrelated, have separate keys for them.
+   */
+  public abstract UntypedContext withValues(
+      Object k1, Object v1, Object k2, Object v2, Object k3, Object v3, Object k4, Object v4);
+
+  public abstract Context toTyped();
+}

--- a/context/src/main/java/io/propagation/thread/DefaultThreadContext.java
+++ b/context/src/main/java/io/propagation/thread/DefaultThreadContext.java
@@ -17,6 +17,7 @@
 package io.propagation.thread;
 
 import io.propagation.Context;
+import io.propagation.UntypedContext;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
@@ -119,6 +120,11 @@ final class DefaultThreadContext extends ThreadContext {
   @Override
   public Executor fixedContextExecutor(final Executor e) {
     return ThreadBinding.fixedContextExecutor(this, e);
+  }
+
+  @Override
+  public UntypedContext toUntyped() {
+    return context.toUntyped();
   }
 
   @Override

--- a/context/src/main/java/io/propagation/thread/DefaultThreadContext.java
+++ b/context/src/main/java/io/propagation/thread/DefaultThreadContext.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright The Propagation.io Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.propagation.thread;
+
+import io.propagation.Context;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class DefaultThreadContext extends ThreadContext {
+  private static final Logger log = Logger.getLogger(DefaultThreadContext.class.getName());
+
+  // Long chains of contexts are suspicious and usually indicate a misuse of Context.
+  // The threshold is arbitrarily chosen.
+  // VisibleForTesting
+  static final int CONTEXT_DEPTH_WARN_THRESH = 1000;
+
+  static final ThreadContext EMPTY = new DefaultThreadContext();
+
+  private final Context context;
+  // The number parents between this context and the root context.
+  final int generation;
+
+  private DefaultThreadContext(Context context, DefaultThreadContext parent) {
+    this.context = context;
+    this.generation = parent.generation + 1;
+    validateGeneration(generation);
+  }
+
+  /** Construct for {@link #EMPTY}. */
+  private DefaultThreadContext() {
+    this.context = Context.empty();
+    this.generation = 0;
+    validateGeneration(generation);
+  }
+
+  // this is used by ThreadContext.of(Context)
+  DefaultThreadContext(Context context) {
+    this.context = context;
+    this.generation = 0;
+    validateGeneration(generation);
+  }
+
+  @Override
+  public <V1> ThreadContext withValue(Context.Key<V1> k1, V1 v1) {
+    return new DefaultThreadContext(context.withValue(k1, v1), this);
+  }
+
+  @Override
+  public <V1, V2> ThreadContext withValues(Context.Key<V1> k1, V1 v1, Context.Key<V2> k2, V2 v2) {
+    return new DefaultThreadContext(context.withValues(k1, v1, k2, v2), this);
+  }
+
+  @Override
+  public <V1, V2, V3> ThreadContext withValues(
+      Context.Key<V1> k1, V1 v1, Context.Key<V2> k2, V2 v2, Context.Key<V3> k3, V3 v3) {
+    return new DefaultThreadContext(context.withValues(k1, v1, k2, v2, k3, v3), this);
+  }
+
+  @Override
+  public <V1, V2, V3, V4> ThreadContext withValues(
+      Context.Key<V1> k1,
+      V1 v1,
+      Context.Key<V2> k2,
+      V2 v2,
+      Context.Key<V3> k3,
+      V3 v3,
+      Context.Key<V4> k4,
+      V4 v4) {
+    return new DefaultThreadContext(context.withValues(k1, v1, k2, v2, k3, v3, k4, v4), this);
+  }
+
+  @Override
+  public ThreadContext attach() {
+    return ThreadBinding.attach(this);
+  }
+
+  @Override
+  public void detach(ThreadContext toAttach) {
+    checkNotNull(toAttach, "toAttach");
+    ThreadBinding.detach(this, toAttach);
+  }
+
+  @Override
+  public void run(Runnable r) {
+    ThreadBinding.run(this, r);
+  }
+
+  @Override
+  public <V> V call(Callable<V> c) throws Exception {
+    return ThreadBinding.call(this, c);
+  }
+
+  @Override
+  public Runnable wrapRunnable(Runnable r) {
+    return ThreadBinding.wrap(this, r);
+  }
+
+  @Override
+  public <C> Callable<C> wrapCallable(Callable<C> c) {
+    return ThreadBinding.wrap(this, c);
+  }
+
+  @Override
+  public Executor fixedContextExecutor(final Executor e) {
+    return ThreadBinding.fixedContextExecutor(this, e);
+  }
+
+  @Override
+  protected <T> T get(Context.Key<T> key) {
+    return key.get(context);
+  }
+
+  private static void checkNotNull(Object reference, String errorMessage) {
+    if (reference == null) {
+      throw new NullPointerException(errorMessage);
+    }
+  }
+
+  /**
+   * If the ancestry chain length is unreasonably long, then print an error to the log and record
+   * the stack trace.
+   */
+  private static void validateGeneration(int generation) {
+    if (generation == CONTEXT_DEPTH_WARN_THRESH) {
+      log.log(
+          Level.SEVERE,
+          "Context ancestry chain length is abnormally long. "
+              + "This suggests an error in application code. "
+              + "Length exceeded: "
+              + CONTEXT_DEPTH_WARN_THRESH,
+          new Exception());
+    }
+  }
+}

--- a/context/src/main/java/io/propagation/thread/DefaultThreadContextStorage.java
+++ b/context/src/main/java/io/propagation/thread/DefaultThreadContextStorage.java
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 
-package io.propagation;
+package io.propagation.thread;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** A {@link ThreadLocal}-based context storage implementation. Used by default. */
-final class ThreadLocalContextStorage extends Context.Storage {
-  private static final Logger log = Logger.getLogger(ThreadLocalContextStorage.class.getName());
+final class DefaultThreadContextStorage extends ThreadContextStorage {
+  private static final Logger log = Logger.getLogger(DefaultThreadContextStorage.class.getName());
 
   /** Currently bound context. */
   // VisibleForTesting
-  static final ThreadLocal<Context> localContext = new ThreadLocal<>();
+  static final ThreadLocal<ThreadContext> localContext = new ThreadLocal<>();
 
   @Override
-  public Context doAttach(Context toAttach) {
-    Context current = current();
+  public ThreadContext doAttach(ThreadContext toAttach) {
+    ThreadContext current = current();
     localContext.set(toAttach);
     return current;
   }
 
   @Override
-  public void detach(Context toDetach, Context toRestore) {
+  public void detach(ThreadContext toDetach, ThreadContext toRestore) {
     if (current() != toDetach) {
       // Log a severe message instead of throwing an exception as the context to attach is assumed
       // to be the correct one and the unbalanced state represents a coding mistake in a lower
@@ -45,7 +45,7 @@ final class ThreadLocalContextStorage extends Context.Storage {
           "Context was not attached when detaching",
           new Throwable().fillInStackTrace());
     }
-    if (toRestore != Context.ROOT) {
+    if (toRestore != ThreadContext.empty()) {
       localContext.set(toRestore);
     } else {
       // Avoid leaking our ClassLoader via ROOT if this Thread is reused across multiple
@@ -61,10 +61,10 @@ final class ThreadLocalContextStorage extends Context.Storage {
   }
 
   @Override
-  public Context current() {
-    Context current = localContext.get();
+  public ThreadContext current() {
+    ThreadContext current = localContext.get();
     if (current == null) {
-      return Context.ROOT;
+      return ThreadContext.empty();
     }
     return current;
   }

--- a/context/src/main/java/io/propagation/thread/ThreadBinding.java
+++ b/context/src/main/java/io/propagation/thread/ThreadBinding.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright The Propagation.io Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.propagation.thread;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class ThreadBinding {
+  private static final Logger log = Logger.getLogger(ThreadBinding.class.getName());
+
+  // VisibleForTesting
+  static ThreadContextStorage storage() {
+    return LazyStorage.storage;
+  }
+
+  // Lazy-loaded storage. Delaying storage initialization until after class initialization makes it
+  // much easier to avoid circular loading since there can still be references to ThreadContext as
+  // long as they don't depend on storage, like key() and currentContextExecutor(). It also makes it
+  // easier to handle exceptions.
+  private static final class LazyStorage {
+    static final ThreadContextStorage storage;
+
+    static {
+      AtomicReference<Throwable> deferredStorageFailure = new AtomicReference<>();
+      storage = createStorage(deferredStorageFailure);
+      Throwable failure = deferredStorageFailure.get();
+      // Logging must happen after storage has been set, as loggers may use ThreadContext.
+      if (failure != null) {
+        log.log(Level.FINE, "Storage override doesn't exist. Using default", failure);
+      }
+    }
+
+    private static ThreadContextStorage createStorage(
+        AtomicReference<? super ClassNotFoundException> deferredStorageFailure) {
+      try {
+        Class<?> clazz =
+            Class.forName("io.propagation.thread.override.ThreadContextStorageOverride");
+        // The override's constructor is prohibited from triggering any code that can loop back to
+        // ThreadContext
+        return clazz.asSubclass(ThreadContextStorage.class).getConstructor().newInstance();
+      } catch (ClassNotFoundException e) {
+        deferredStorageFailure.set(e);
+        return new DefaultThreadContextStorage();
+      } catch (Exception e) {
+        throw new RuntimeException("Storage override failed to initialize", e);
+      }
+    }
+  }
+
+  static ThreadContext current() {
+    ThreadContext current = storage().current();
+    if (current == null) {
+      return ThreadContext.empty();
+    }
+    return current;
+  }
+
+  static ThreadContext attach(ThreadContext toAttach) {
+    ThreadContext prev = storage().doAttach(toAttach);
+    if (prev == null) {
+      return ThreadContext.empty();
+    }
+    return prev;
+  }
+
+  static void detach(ThreadContext toDetach, ThreadContext toAttach) {
+    storage().detach(toDetach, toAttach);
+  }
+
+  static void run(ThreadContext context, Runnable r) {
+    ThreadContext previous = attach(context);
+    try {
+      r.run();
+    } finally {
+      detach(context, previous);
+    }
+  }
+
+  static <V> V call(ThreadContext context, Callable<V> c) throws Exception {
+    ThreadContext previous = attach(context);
+    try {
+      return c.call();
+    } finally {
+      detach(context, previous);
+    }
+  }
+
+  static Runnable wrap(final ThreadContext context, final Runnable r) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        ThreadContext previous = attach(context);
+        try {
+          r.run();
+        } finally {
+          detach(context, previous);
+        }
+      }
+    };
+  }
+
+  static <C> Callable<C> wrap(final ThreadContext context, final Callable<C> c) {
+    return new Callable<C>() {
+      @Override
+      public C call() throws Exception {
+        ThreadContext previous = attach(context);
+        try {
+          return c.call();
+        } finally {
+          detach(context, previous);
+        }
+      }
+    };
+  }
+
+  static Executor fixedContextExecutor(final ThreadContext context, final Executor e) {
+    final class FixedContextExecutor implements Executor {
+      @Override
+      public void execute(Runnable r) {
+        e.execute(wrap(context, r));
+      }
+    }
+
+    return new FixedContextExecutor();
+  }
+
+  static Executor currentContextExecutor(final Executor e) {
+    final class CurrentContextExecutor implements Executor {
+      @Override
+      public void execute(Runnable r) {
+        e.execute(wrap(current(), r));
+      }
+    }
+
+    return new CurrentContextExecutor();
+  }
+
+  private ThreadBinding() {}
+}

--- a/context/src/main/java/io/propagation/thread/ThreadContext.java
+++ b/context/src/main/java/io/propagation/thread/ThreadContext.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright The Propagation.io Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.propagation.thread;
+
+import io.propagation.Context;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+
+/**
+ * A context propagation mechanism which can carry scoped-values across API boundaries and between
+ * threads. Examples of state propagated via context include:
+ *
+ * <ul>
+ *   <li>Security principals and credentials.
+ *   <li>Local and distributed tracing information.
+ * </ul>
+ *
+ * <p>A ThreadContext object can be {@link #attach attached} to the {@link ThreadContextStorage},
+ * which effectively forms a <b>scope</b> for the context. The scope is bound to the current thread.
+ * Within a scope, its ThreadContext is accessible even across API boundaries, through {@link
+ * #current}. The scope is later exited by {@link #detach detaching} the ThreadContext.
+ *
+ * <p>ThreadContext objects are immutable and inherit state from their parent. To add or overwrite
+ * the current state a new context object must be created and then attached, replacing the
+ * previously bound context. For example:
+ *
+ * <pre>
+ *   ThreadContext withCredential = ThreadContext.current().withValue("key", cred);
+ *   withCredential.run(new Runnable() {
+ *     public void run() {
+ *        readUserRecords(userId, ThreadContext.current().get("key"));
+ *     }
+ *   });
+ * </pre>
+ *
+ * <p>Notes and cautions on use:
+ *
+ * <ul>
+ *   <li>Every {@code attach()} should have a {@code detach()} in the same method. Breaking this
+ *       rules may lead to memory leaks.
+ *   <li>While ThreadContext objects are immutable they do not place such a restriction on the state
+ *       they store.
+ *   <li>ThreadContext is not intended for passing optional parameters to an API and developers
+ *       should take care to avoid excessive dependence on context when designing an API.
+ *   <li>Do not mock this class. Use {@link #empty()} for a non-null instance.
+ * </ul>
+ */
+/* @DoNotMock("Use empty() for a non-null ThreadContext") // commented out to avoid dependencies  */
+public abstract class ThreadContext extends Context {
+
+  /**
+   * Create a {@link Key} with the given debug name. Multiple different keys may have the same name;
+   * the name is intended for debugging purposes and does not impact behavior.
+   */
+  public static <T> Key<T> key(String name) {
+    return new Key<>(name);
+  }
+
+  /**
+   * Create a {@link Context.Key} with the given debug name and default value. Multiple different
+   * keys may have the same name; the name is intended for debugging purposes and does not impact
+   * behavior.
+   */
+  public static <T> Key<T> keyWithDefault(String name, T defaultValue) {
+    return new Key<>(name, defaultValue);
+  }
+
+  /**
+   * The logical root context which is the ultimate ancestor of all contexts.
+   *
+   * <p>Never assume this is the default context for new threads, because {@link
+   * ThreadContextStorage} may define a default context that is different.
+   */
+  public static ThreadContext empty() {
+    return DefaultThreadContext.EMPTY;
+  }
+
+  /** Return the context associated with the current scope, will never return {@code null}. */
+  public static ThreadContext current() {
+    return ThreadBinding.current();
+  }
+
+  /** Convert the {@link Context} to a {@link ThreadContext}. */
+  public static ThreadContext wrap(Context context) {
+    if (context instanceof ThreadContext) {
+      return (ThreadContext) context;
+    } else {
+      return new DefaultThreadContext(context);
+    }
+  }
+
+  @Override
+  public abstract <V1> ThreadContext withValue(Context.Key<V1> k1, V1 v1);
+
+  @Override
+  public abstract <V1, V2> ThreadContext withValues(
+      Context.Key<V1> k1, V1 v1, Context.Key<V2> k2, V2 v2);
+
+  @Override
+  public abstract <V1, V2, V3> ThreadContext withValues(
+      Context.Key<V1> k1, V1 v1, Context.Key<V2> k2, V2 v2, Context.Key<V3> k3, V3 v3);
+
+  @Override
+  public abstract <V1, V2, V3, V4> ThreadContext withValues(
+      Context.Key<V1> k1,
+      V1 v1,
+      Context.Key<V2> k2,
+      V2 v2,
+      Context.Key<V3> k3,
+      V3 v3,
+      Context.Key<V4> k4,
+      V4 v4);
+
+  /**
+   * Attach this context, thus enter a new scope within which this context is {@link #current}. The
+   * previously current context is returned.
+   *
+   * <p>Instead of using {@code attach()} and {@link #detach(ThreadContext)} most use-cases are
+   * better served by using the {@link #run(Runnable)} or {@link
+   * #call(java.util.concurrent.Callable)} to execute work immediately within a context's scope. If
+   * work needs to be done in other threads it is recommended to use the 'wrap' methods or to use a
+   * propagating executor.
+   *
+   * <p>All calls to {@code attach()} should have a corresponding {@link #detach(ThreadContext)}
+   * within the same method:
+   *
+   * <pre>{@code ThreadContext previous = someContext.attach();
+   * try {
+   *   // Do work
+   * } finally {
+   *   someContext.detach(previous);
+   * }}</pre>
+   */
+  public abstract ThreadContext attach();
+
+  /**
+   * Reverse an {@code attach()}, restoring the previous context and exiting the current scope.
+   *
+   * <p>This context should be the same context that was previously {@link #attach attached}. The
+   * provided replacement should be what was returned by the same {@link #attach attach()} call. If
+   * an {@code attach()} and a {@code detach()} meet above requirements, they match.
+   *
+   * <p>It is expected that between any pair of matching {@code attach()} and {@code detach()}, all
+   * {@code attach()}es and {@code detach()}es are called in matching pairs. If this method finds
+   * that this context is not {@link #current current}, either you or some code in-between are not
+   * detaching correctly, and a SEVERE message will be logged but the context to attach will still
+   * be bound. <strong>Never</strong> use {@code ThreadContext.current().detach()}, as this will
+   * compromise this error-detecting mechanism.
+   */
+  public abstract void detach(ThreadContext toAttach);
+
+  /**
+   * Immediately run a {@link Runnable} with this context as the {@link #current} context.
+   *
+   * @param r {@link Runnable} to run.
+   */
+  public abstract void run(Runnable r);
+
+  /**
+   * Immediately call a {@link Callable} with this context as the {@link #current} context.
+   *
+   * @param c {@link Callable} to call.
+   * @return result of call.
+   */
+  public abstract <V> V call(Callable<V> c) throws Exception;
+
+  /**
+   * Wrap a {@link Runnable} so that it executes with this context as the {@link #current} context.
+   */
+  public abstract Runnable wrapRunnable(final Runnable r);
+
+  /**
+   * Wrap a {@link Callable} so that it executes with this context as the {@link #current} context.
+   */
+  public abstract <C> Callable<C> wrapCallable(final Callable<C> c);
+
+  /**
+   * Wrap an {@link Executor} so that it always executes with this context as the {@link #current}
+   * context. It is generally expected that {@link #currentContextExecutor(Executor)} would be used
+   * more commonly than this method.
+   *
+   * <p>One scenario in which this executor may be useful is when a single thread is sharding work
+   * to multiple threads.
+   *
+   * @see #currentContextExecutor(Executor)
+   */
+  public abstract Executor fixedContextExecutor(final Executor e);
+
+  /**
+   * Create an executor that propagates the {@link #current} context when {@link Executor#execute}
+   * is called as the {@link #current} context of the {@code Runnable} scheduled. <em>Note that this
+   * is a static method.</em>
+   *
+   * @see #fixedContextExecutor(Executor)
+   */
+  public static Executor currentContextExecutor(final Executor e) {
+    return ThreadBinding.currentContextExecutor(e);
+  }
+
+  @Override
+  protected abstract <T> T get(Context.Key<T> key);
+
+  /** Key for indexing values stored in a context. */
+  public static final class Key<T> extends Context.Key<T> {
+
+    Key(String name) {
+      super(name);
+    }
+
+    Key(String name, T defaultValue) {
+      super(name, defaultValue);
+    }
+
+    /** Get the value from the specified context for this key. */
+    public T get() {
+      return get(ThreadContext.current());
+    }
+  }
+}

--- a/context/src/main/java/io/propagation/thread/ThreadContextStorage.java
+++ b/context/src/main/java/io/propagation/thread/ThreadContextStorage.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Propagation.io Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.propagation.thread;
+
+/**
+ * Defines the mechanisms for attaching and detaching the "current" context. The constructor for
+ * extending classes <em>must not</em> trigger any activity that can use ThreadContext, which
+ * includes logging, otherwise it can trigger an infinite initialization loop. Extending classes
+ * must not assume that only one instance will be created; ThreadContext guarantees it will only use
+ * one instance, but it may create multiple and then throw away all but one.
+ *
+ * <p>The default implementation will put the current context in a {@link ThreadLocal}. If an
+ * alternative implementation named {@code
+ * io.propagation.thread.override.ThreadContextStorageOverride} exists in the classpath, it will be
+ * used instead of the default implementation.
+ *
+ * <p>This API is <a href="https://github.com/grpc/grpc-java/issues/2462">experimental</a> and
+ * subject to change.
+ */
+public abstract class ThreadContextStorage {
+  /**
+   * Implements {@link ThreadBinding#attach}.
+   *
+   * <p>Caution: {@link ThreadBinding#attach} interprets a return value of {@code null} to mean the
+   * same thing as {@link ThreadContext#empty}.
+   *
+   * <p>See also: {@link #current}.
+   *
+   * @param toAttach the context to be attached
+   * @return A {@link ThreadContext} that should be passed back into {@link #detach(ThreadContext,
+   *     ThreadContext)} as the {@code toRestore} parameter. {@code null} is a valid return value,
+   *     but see caution note.
+   */
+  public abstract ThreadContext doAttach(ThreadContext toAttach);
+
+  /**
+   * Implements {@link ThreadBinding#detach}.
+   *
+   * @param toDetach the context to be detached. Should be, or be equivalent to, the current context
+   *     of the current scope
+   * @param toRestore the context to be the current. Should be, or be equivalent to, the context of
+   *     the outer scope
+   */
+  public abstract void detach(ThreadContext toDetach, ThreadContext toRestore);
+
+  /**
+   * Implements {@link ThreadBinding#current}.
+   *
+   * <p>Caution: {@link ThreadBinding#current} interprets a return value of {@code null} to mean the
+   * same thing as {@code ThreadContext{@link ThreadContext#empty }}.
+   *
+   * <p>See also {@link #doAttach(ThreadContext)}.
+   *
+   * @return The context of the current scope. {@code null} is a valid return value, but see caution
+   *     note.
+   */
+  public abstract ThreadContext current();
+}

--- a/context/src/test/java/io/propagation/PersistentHashArrayMappedTrieTest.java
+++ b/context/src/test/java/io/propagation/PersistentHashArrayMappedTrieTest.java
@@ -39,8 +39,8 @@ public class PersistentHashArrayMappedTrieTest {
     Key key = new Key(0);
     Object value1 = new Object();
     Object value2 = new Object();
-    Leaf<Key, Object> leaf = new Leaf<>(key, value1);
-    Node<Key, Object> ret = leaf.put(key, value2, key.hashCode(), 0);
+    Leaf leaf = new Leaf(key, value1);
+    Node ret = leaf.put(key, value2, key.hashCode(), 0);
     assertTrue(ret instanceof Leaf);
     assertSame(value2, ret.get(key, key.hashCode(), 0));
 
@@ -56,8 +56,8 @@ public class PersistentHashArrayMappedTrieTest {
     Key key2 = new Key(0);
     Object value1 = new Object();
     Object value2 = new Object();
-    Leaf<Key, Object> leaf = new Leaf<>(key1, value1);
-    Node<Key, Object> ret = leaf.put(key2, value2, key2.hashCode(), 0);
+    Leaf leaf = new Leaf(key1, value1);
+    Node ret = leaf.put(key2, value2, key2.hashCode(), 0);
     assertTrue(ret instanceof CollisionLeaf);
     assertSame(value1, ret.get(key1, key1.hashCode(), 0));
     assertSame(value2, ret.get(key2, key2.hashCode(), 0));
@@ -75,8 +75,8 @@ public class PersistentHashArrayMappedTrieTest {
     Key key2 = new Key(1);
     Object value1 = new Object();
     Object value2 = new Object();
-    Leaf<Key, Object> leaf = new Leaf<>(key1, value1);
-    Node<Key, Object> ret = leaf.put(key2, value2, key2.hashCode(), 0);
+    Leaf leaf = new Leaf(key1, value1);
+    Node ret = leaf.put(key2, value2, key2.hashCode(), 0);
     assertTrue(ret instanceof CompressedIndex);
     assertSame(value1, ret.get(key1, key1.hashCode(), 0));
     assertSame(value2, ret.get(key2, key2.hashCode(), 0));
@@ -92,13 +92,13 @@ public class PersistentHashArrayMappedTrieTest {
   public void collisionLeaf_assertKeysDifferent() {
     Key key1 = new Key(0);
     thrown.expect(AssertionError.class);
-    new CollisionLeaf<>(key1, new Object(), key1, new Object());
+    new CollisionLeaf(key1, new Object(), key1, new Object());
   }
 
   @Test
   public void collisionLeaf_assertHashesSame() {
     thrown.expect(AssertionError.class);
-    new CollisionLeaf<>(new Key(0), new Object(), new Key(1), new Object());
+    new CollisionLeaf(new Key(0), new Object(), new Key(1), new Object());
   }
 
   @Test
@@ -109,9 +109,9 @@ public class PersistentHashArrayMappedTrieTest {
     Object value1 = new Object();
     Object value2 = new Object();
     Object insertValue = new Object();
-    CollisionLeaf<Key, Object> leaf = new CollisionLeaf<>(key1, value1, key2, value2);
+    CollisionLeaf leaf = new CollisionLeaf(key1, value1, key2, value2);
 
-    Node<Key, Object> ret = leaf.put(insertKey, insertValue, insertKey.hashCode(), 0);
+    Node ret = leaf.put(insertKey, insertValue, insertKey.hashCode(), 0);
     assertTrue(ret instanceof CompressedIndex);
     assertSame(value1, ret.get(key1, key1.hashCode(), 0));
     assertSame(value2, ret.get(key2, key2.hashCode(), 0));
@@ -131,9 +131,9 @@ public class PersistentHashArrayMappedTrieTest {
     Object originalValue = new Object();
     Key key = new Key(replaceKey.hashCode());
     Object value = new Object();
-    CollisionLeaf<Key, Object> leaf = new CollisionLeaf<>(replaceKey, originalValue, key, value);
+    CollisionLeaf leaf = new CollisionLeaf(replaceKey, originalValue, key, value);
     Object replaceValue = new Object();
-    Node<Key, Object> ret = leaf.put(replaceKey, replaceValue, replaceKey.hashCode(), 0);
+    Node ret = leaf.put(replaceKey, replaceValue, replaceKey.hashCode(), 0);
     assertTrue(ret instanceof CollisionLeaf);
     assertSame(replaceValue, ret.get(replaceKey, replaceKey.hashCode(), 0));
     assertSame(value, ret.get(key, key.hashCode(), 0));
@@ -153,9 +153,9 @@ public class PersistentHashArrayMappedTrieTest {
     Object value1 = new Object();
     Object value2 = new Object();
     Object value3 = new Object();
-    CollisionLeaf<Key, Object> leaf = new CollisionLeaf<>(key1, value1, key2, value2);
+    CollisionLeaf leaf = new CollisionLeaf(key1, value1, key2, value2);
 
-    Node<Key, Object> ret = leaf.put(key3, value3, key3.hashCode(), 0);
+    Node ret = leaf.put(key3, value3, key3.hashCode(), 0);
     assertTrue(ret instanceof CollisionLeaf);
     assertSame(value1, ret.get(key1, key1.hashCode(), 0));
     assertSame(value2, ret.get(key2, key2.hashCode(), 0));
@@ -175,11 +175,11 @@ public class PersistentHashArrayMappedTrieTest {
     final Key key2 = new Key(19);
     final Object value1 = new Object();
     final Object value2 = new Object();
-    Leaf<Key, Object> leaf1 = new Leaf<>(key1, value1);
-    Leaf<Key, Object> leaf2 = new Leaf<>(key2, value2);
+    Leaf leaf1 = new Leaf(key1, value1);
+    Leaf leaf2 = new Leaf(key2, value2);
     class Verifier {
-      private void verify(Node<Key, Object> ret) {
-        CompressedIndex<Key, Object> collisionLeaf = (CompressedIndex<Key, Object>) ret;
+      private void verify(Node ret) {
+        CompressedIndex collisionLeaf = (CompressedIndex) ret;
         assertEquals((1 << 7) | (1 << 19), collisionLeaf.bitmap);
         assertEquals(2, collisionLeaf.values.length);
         assertSame(value1, collisionLeaf.values[0].get(key1, key1.hashCode(), 0));
@@ -206,15 +206,14 @@ public class PersistentHashArrayMappedTrieTest {
     final Key key2 = new Key(31 << 5 | 1); // 5 bit regions: (31, 1)
     final Object value1 = new Object();
     final Object value2 = new Object();
-    Leaf<Key, Object> leaf1 = new Leaf<>(key1, value1);
-    Leaf<Key, Object> leaf2 = new Leaf<>(key2, value2);
+    Leaf leaf1 = new Leaf(key1, value1);
+    Leaf leaf2 = new Leaf(key2, value2);
     class Verifier {
-      private void verify(Node<Key, Object> ret) {
-        CompressedIndex<Key, Object> collisionInternal = (CompressedIndex<Key, Object>) ret;
+      private void verify(Node ret) {
+        CompressedIndex collisionInternal = (CompressedIndex) ret;
         assertEquals(1 << 1, collisionInternal.bitmap);
         assertEquals(1, collisionInternal.values.length);
-        CompressedIndex<Key, Object> collisionLeaf =
-            (CompressedIndex<Key, Object>) collisionInternal.values[0];
+        CompressedIndex collisionLeaf = (CompressedIndex) collisionInternal.values[0];
         assertEquals((1 << 31) | (1 << 17), collisionLeaf.bitmap);
         assertSame(value1, ret.get(key1, key1.hashCode(), 0));
         assertSame(value2, ret.get(key2, key2.hashCode(), 0));

--- a/context/src/test/java/io/propagation/thread/StaticTestingClassLoader.java
+++ b/context/src/test/java/io/propagation/thread/StaticTestingClassLoader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.propagation;
+package io.propagation.thread;
 
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;


### PR DESCRIPTION
I recommend to start by reviewing the updated README in this PR, which tries to explain 
motivation, copied here:

------------------------------

# Propagation.io
A standalone context propagation library for Java that is focused on improving interoperability across existing context propagation APIs like gRPC Context and Reactor.

# Design questions

### Should the context have a thread-based "current" concept?

Having a thread-based "current" context makes sense in some environments, but doesn't make sense in others.

Reflecting that, some existing libraries like gRPC Context have this concept, while some existing libraries like Reactor do not.

So, in order to improve interoperability across existing context propagation APIs, the current proposal provides both options on top of the same immutable data structure in order to make transitioning between them efficient (see `Context` and `ThreadContext`).

### Should the context have typed keys?

Having typed keys seems to be generally preferable (we are interested to learn more about use cases where they are not!).

However, some existing libraries like gRPC Context use typed keys, and some existing libraries like Reactor do not.

So, in order to improve interoperability across existing context propagation APIs, the current proposal provides both options on top of the same immutable data structure in order to make transitioning between them efficient (see `Context` and `UntypedContext`).

\[Note: there's no `UntypedThreadContext` yet, we need to investigate more libraries and hear from more folks to know if this is needed.]

### Should this project support Java 7?

Supporting Java 7 limits some design choices, but is a requirement for both gRPC and OpenTelemetry.

### Should context be an interface or an abstract class?

Since we are limited to Java 7, `Context`, `ThreadContext`, and `UntypedContext` have been implemented as abstract classes instead of interfaces so that their related static methods can be collocated in the same place, making the API surface feel smaller and improving discoverability.

Alternatively, we could make them interfaces and move the static methods to corresponding util classes (e.g. `Contexts`, `ThreadContexts`, and `UntypedContexts`), which would give implementations more flexibility.

------------------------------
(End of README)

And then here are some notes that hopefully help while reviewing the code:

`Context`

* By moving `generation` to `ThreadContext`, was able to implement `Context` directly using `Node` which improves memory and helps optimize interop between the different context implementations. My thought was that `generation` issues are probably more of an issue when binding the context to the thread, compared to passing the context around directly.
* Intellij complained when I put constant `EMPTY` in this class ("Referencing subclass from superclass initializer might lead to class loading deadlock") so I made this a static method `empty()` instead.

`ThreadContext`

* An alternative name could be `CurrentContext`, but I liked `ThreadContext` because it's explicit about being tied to the thread, and "current" is a little more vague, (e.g. current subscriber context in Reactor?)
* Same issue as above with constant `EMPTY/ROOT` in this class. Named the method `empty()` instead of `root()` since `ThreadContext` extends `Context`, and I wanted the method to hide `Context.empty()`. Also, it's not quite a "root" in the same sense that it used to be before the `ThreadContext` split.
* Extends `Context`, and the `withValues(..)` methods are overridden to narrow the return type.
  * This works out nicely for APIs that accept and return `Context`. The APIs can be written against `Context`, and if the API user is using `ThreadContext`, the user can pass `ThreadContext` directly to the API. And if the API calls `withValue` on the context that was passed in and returns a new context, the returned context will still be a `ThreadContext`, so that when the user calls `ThreadContext.wrap(context)` to convert the returned `Context` back into a `ThreadContext` it will essentially be a no-op.
* Renamed `wrap(Runnable)` and `wrap(Callable)` to `wrapRunnable(Runnable)` and `wrapCallable(Callable)` so that they wouldn't look quite so similar to the static `wrap(Context)` method, but maybe still not ideal.

`ThreadBinding`

* Split out from `DefaultThreadContext` just to keep classes smaller and more narrowly scoped (no strong opinion here).

`ThreadContextStorage`

* Extracted `ThreadContext.Storage` out into top-level class so that it doesn't take up space in `ThreadContext` (no strong opinion here either).

`Context.Key`

* Typed contexts do not have public getter, value must be accessed through `Key`, this is not consistent with untyped context, which has getter, but I think this difference could be good, as it emphasizes the fundamental difference between typed and untyped contexts.
* Class changed to non-final so that it can be subclassed by `ThreadContext.Key`.

`ThreadContext.Key`

* Extends `Context.Key` to add convenience no-arg getter that uses `ThreadContext.current()`.

These are the methods for converting between the different context types. I think the naming and location (instance vs static) could likely be improved.
* Context → ThreadContext
  * `ThreadContext.wrap(context)`
  * This is not an instance method on `Context` because that felt like leaking thread binding concept into the `Context` class.
  * Not totally sold on the "wrap/unwrap" terminology.
  * Could be renamed `ThreadContext.of(Context)` but not sure what the opposite "unwrap" method would be named in this case.
* ThreadContext → Context
  * `threadContext.unwrap()`
  * Like mentioned above, not totally sold on the "wrap/unwrap" terminology.
* Context → UntypedContext
  * `context.toUntyped()`
  * This isn't a static `wrap` method on `UntypedContext` (similar to `ThreadContext` above), because it doesn't work for anything that implements `Context`, it's only translates between very specific implementations of `Context` and `UntypedContext`.
* UntypedContext → Context
  * `untypedContext.toTyped()`

The existing gRPC Context tests have been adapted to test `ThreadContext`. There are no tests yet for `Context` or `UntypedContext`, this will need to be addressed.

Probably lots more stuff that I'm not thinking of or haven't noticed.

Feel free to comment on both big design issues and small implementation/doc issues. All types of feedback is welcome and needed.